### PR TITLE
Fix typos and modify titles to be recognized as headings

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@ Package update provides functionality to implement secure, self-updating Go prog
 
 For complete updating solutions please see Equinox (https://equinox.io) and go-tuf (https://github.com/flynn/go-tuf).
 
-Basic Example
+# Basic Example
 
 This example shows how to update a program remotely from a URL.
 
@@ -30,8 +30,7 @@ This example shows how to update a program remotely from a URL.
 		return err
 	}
 
-
-Binary Patching
+# Binary Patching
 
 Go binaries can often be large. It can be advantageous to only ship a binary patch to a client
 instead of the complete program text of a new version.
@@ -56,7 +55,7 @@ may be applied by implementing the Patcher interface.
 		return err
 	}
 
-Checksum Verification
+# Checksum Verification
 
 Updating executable code on a computer can be a dangerous operation unless you
 take the appropriate steps to guarantee the authenticity of the new code. While
@@ -67,7 +66,7 @@ selfupdate validates SHA256 checksums by default, but this is pluggable via the 
 property on the Options struct.
 
 This example shows how to guarantee that the newly-updated binary is verified to
-have an appropriate checksum (that was otherwise retrived via a secure channel)
+have an appropriate checksum (that was otherwise retrieved via a secure channel)
 specified as a hex string.
 
 	import (
@@ -94,7 +93,7 @@ specified as a hex string.
 		return err
 	}
 
-Cryptographic Signature Verification
+# Cryptographic Signature Verification
 
 Cryptographic verification of new code from an update is an extremely important way to guarantee the
 security and integrity of your updates.
@@ -132,15 +131,14 @@ with the private key and distribute the signature along with the selfupdate.
 		return err
 	}
 
+# Building Single-File Go Binaries
 
-Building Single-File Go Binaries
-
-In order to update a Go application with selfupdate, you must distributed it as a single executable.
+In order to update a Go application with selfupdate, you must distribute it as a single executable.
 This is often easy, but some applications require static assets (like HTML and CSS asset files or TLS certificates).
 In order to update applications like these, you'll want to make sure to embed those asset files into
 the distributed binary with a tool like go-bindata (my favorite): https://github.com/jteeuwen/go-bindata
 
-Non-Goals
+# Non-Goals
 
 Mechanisms and protocols for determining whether an update should be applied and, if so, which one are
 out of scope for this package. Please consult go-tuf (https://github.com/flynn/go-tuf) or Equinox (https://equinox.io)
@@ -148,8 +146,7 @@ for more complete solutions.
 
 selfupdate only works for self-updating applications that are distributed as a single binary, i.e.
 applications that do not have additional assets or dependency files.
-Updating application that are distributed as mutliple on-disk files is out of scope, although this
+Updating application that are distributed as multiple on-disk files is out of scope, although this
 may change in future versions of this library.
-
 */
 package selfupdate


### PR DESCRIPTION
Headings were introduced in Go 1.19: https://go.dev/doc/comment#headings