### PR TITLE
Try to fix library issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/selfupdate
 
-go 1.14
+go 1.21
 
 require (
 	aead.dev/minisign v0.2.0


### PR DESCRIPTION
The minisign library may require a higher version to be pulled? Modified to available in 1.21