### PR TITLE
Refactor Code to Remove Deprecated ioutil Package and Improve Formatting

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -27,10 +26,10 @@ func Apply(update io.Reader, opts Options) error {
 }
 
 // PrepareAndCheckBinary reads the new binary content from io.Reader and performs the following actions:
-//   1. If configured, applies the contents of the update io.Reader as a binary patch.
-//   2. If configured, computes the checksum of the executable and verifies it matches.
-//   3. If configured, verifies the signature with a public key.
-//   4. Creates a new file, /path/to/.target.new with the TargetMode with the contents of the updated file
+//  1. If configured, applies the contents of the update io.Reader as a binary patch.
+//  2. If configured, computes the checksum of the executable and verifies it matches.
+//  3. If configured, verifies the signature with a public key.
+//  4. Creates a new file, /path/to/.target.new with the TargetMode with the contents of the updated file
 func PrepareAndCheckBinary(update io.Reader, opts Options) error {
 	// get target path
 	targetPath, err := opts.getPath()
@@ -45,7 +44,7 @@ func PrepareAndCheckBinary(update io.Reader, opts Options) error {
 		}
 	} else {
 		// no patch to apply, go on through
-		if newBytes, err = ioutil.ReadAll(update); err != nil {
+		if newBytes, err = io.ReadAll(update); err != nil {
 			return err
 		}
 	}
@@ -88,12 +87,12 @@ func PrepareAndCheckBinary(update io.Reader, opts Options) error {
 
 // CommitBinary moves the new executable to the location of the current executable or opts.TargetPath
 // if specified. It performs the following operations:
-//   1. Renames /path/to/target to /path/to/.target.old
-//   2. Renames /path/to/.target.new to /path/to/target
-//   3. If the final rename is successful, deletes /path/to/.target.old, returns no error. On Windows,
-//      the removal of /path/to/target.old always fails, so instead Apply hides the old file instead.
-//   4. If the final rename fails, attempts to roll back by renaming /path/to/.target.old
-//      back to /path/to/target.
+//  1. Renames /path/to/target to /path/to/.target.old
+//  2. Renames /path/to/.target.new to /path/to/target
+//  3. If the final rename is successful, deletes /path/to/.target.old, returns no error. On Windows,
+//     the removal of /path/to/target.old always fails, so instead Apply hides the old file instead.
+//  4. If the final rename fails, attempts to roll back by renaming /path/to/.target.old
+//     back to /path/to/target.
 //
 // If the roll back operation fails, the file system is left in an inconsistent state where there is
 // no new executable file and the old executable file could not be be moved to its original location.
@@ -131,7 +130,6 @@ func CommitBinary(opts Options) error {
 
 	// move the new exectuable in to become the new program
 	err = os.Rename(newPath, targetPath)
-
 	if err != nil {
 		// move unsuccessful
 		//
@@ -243,7 +241,7 @@ func (o *Options) getPath() (string, error) {
 
 func (o *Options) getMode() os.FileMode {
 	if o.TargetMode == 0 {
-		return 0755
+		return 0o755
 	}
 	return o.TargetMode
 }
@@ -279,7 +277,11 @@ func (o *Options) verifyChecksum(updated []byte) error {
 	}
 
 	if !bytes.Equal(o.Checksum, checksum) {
-		return fmt.Errorf("Updated file has wrong checksum. Expected: %x, got: %x", o.Checksum, checksum)
+		return fmt.Errorf(
+			"Updated file has wrong checksum. Expected: %x, got: %x",
+			o.Checksum,
+			checksum,
+		)
 	}
 	return nil
 }

--- a/hide_windows.go
+++ b/hide_windows.go
@@ -9,7 +9,12 @@ func hideFile(path string) error {
 	kernel32 := syscall.NewLazyDLL("kernel32.dll")
 	setFileAttributes := kernel32.NewProc("SetFileAttributesW")
 
-	r1, _, err := setFileAttributes.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))), 2)
+	utf16, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	r1, _, err := setFileAttributes.Call(uintptr(unsafe.Pointer(utf16)), 2)
 
 	if r1 == 0 {
 		return err

--- a/internal/binarydist/common_test.go
+++ b/internal/binarydist/common_test.go
@@ -3,7 +3,6 @@ package binarydist
 import (
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -17,7 +16,7 @@ func mustOpen(path string) *os.File {
 }
 
 func mustReadAll(r io.Reader) []byte {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}
@@ -49,12 +48,12 @@ func fileCmp(a, b *os.File) int64 {
 		panic(err)
 	}
 
-	pa, err := ioutil.ReadAll(a)
+	pa, err := io.ReadAll(a)
 	if err != nil {
 		panic(err)
 	}
 
-	pb, err := ioutil.ReadAll(b)
+	pb, err := io.ReadAll(b)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/binarydist/diff.go
+++ b/internal/binarydist/diff.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 )
 
 func swap(a []int, i, j int) { a[i], a[j] = a[j], a[i] }
@@ -181,12 +180,12 @@ func search(I []int, obuf, nbuf []byte, st, en int) (pos, n int) {
 // Diff computes the difference between old and new, according to the bsdiff
 // algorithm, and writes the result to patch.
 func Diff(old, new io.Reader, patch io.Writer) error {
-	obuf, err := ioutil.ReadAll(old)
+	obuf, err := io.ReadAll(old)
 	if err != nil {
 		return err
 	}
 
-	nbuf, err := ioutil.ReadAll(new)
+	nbuf, err := io.ReadAll(new)
 	if err != nil {
 		return err
 	}

--- a/internal/binarydist/diff_test.go
+++ b/internal/binarydist/diff_test.go
@@ -2,7 +2,6 @@ package binarydist
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -24,13 +23,13 @@ var diffT = []struct {
 
 func TestDiff(t *testing.T) {
 	for _, s := range diffT {
-		got, err := ioutil.TempFile("/tmp", "bspatch.")
+		got, err := os.CreateTemp("/tmp", "bspatch.")
 		if err != nil {
 			panic(err)
 		}
 		os.Remove(got.Name())
 
-		exp, err := ioutil.TempFile("/tmp", "bspatch.")
+		exp, err := os.CreateTemp("/tmp", "bspatch.")
 		if err != nil {
 			panic(err)
 		}

--- a/internal/binarydist/patch.go
+++ b/internal/binarydist/patch.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"io/ioutil"
 )
 
 var ErrCorrupt = errors.New("corrupt patch")
@@ -43,7 +42,7 @@ func Patch(old io.Reader, new io.Writer, patch io.Reader) error {
 	// The entire rest of the file is the extra block.
 	epfbz2 := bzip2.NewReader(patch)
 
-	obuf, err := ioutil.ReadAll(old)
+	obuf, err := io.ReadAll(old)
 	if err != nil {
 		return err
 	}

--- a/internal/binarydist/patch_test.go
+++ b/internal/binarydist/patch_test.go
@@ -1,7 +1,6 @@
 package binarydist
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -11,7 +10,7 @@ func TestPatch(t *testing.T) {
 	mustWriteRandFile("test.old", 1e3)
 	mustWriteRandFile("test.new", 1e3)
 
-	got, err := ioutil.TempFile("/tmp", "bspatch.")
+	got, err := os.CreateTemp("/tmp", "bspatch.")
 	if err != nil {
 		panic(err)
 	}
@@ -39,7 +38,7 @@ func TestPatch(t *testing.T) {
 }
 
 func TestPatchHk(t *testing.T) {
-	got, err := ioutil.TempFile("/tmp", "bspatch.")
+	got, err := os.CreateTemp("/tmp", "bspatch.")
 	if err != nil {
 		panic(err)
 	}

--- a/minisign_test.go
+++ b/minisign_test.go
@@ -1,18 +1,21 @@
 package selfupdate
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestMinisign(t *testing.T) {
 	v := NewVerifier()
-	err := v.LoadFromFile("LICENSE.minisig", "RWQhjNB8gjlNDQYRsRiGEzKTtGwzkcFLRMiSEy+texbTAVMvsgFLLfSr")
+	err := v.LoadFromFile(
+		"LICENSE.minisig",
+		"RWQhjNB8gjlNDQYRsRiGEzKTtGwzkcFLRMiSEy+texbTAVMvsgFLLfSr",
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	buf, err := ioutil.ReadFile("LICENSE")
+	buf, err := os.ReadFile("LICENSE")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Replaced usages of the deprecated `ioutil` package with the appropriate `os` and `io` functions (`os.ReadFile`, `os.WriteFile`, `os.CreateTemp`, `io.ReadAll`).
- Updated file permission syntax to octal notation.