### PR TITLE
Handle .old file normalization

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -12,19 +12,21 @@ jobs:
   vulncheck:
     name: Analysis
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [ 1.19 ]
     steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-        check-latest: true
-    - name: Get govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
-      shell: bash
-    - name: Run govulncheck
-      run: govulncheck ./...
-      shell: bash
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0 # Same as 'go x.y.z' in go.mod
+          cache: false
+      - name: Get official govulncheck
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git config --global url."https://minio-bot:${TOKEN}@github.com".insteadOf "https://github.com"
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck -show verbose -scan package ./...
+        shell: bash

--- a/apply_test.go
+++ b/apply_test.go
@@ -247,3 +247,61 @@ func sign(parsePrivKey func([]byte) (crypto.Signer, error), privatePEM string, s
 
 	return sig
 }
+
+func TestNormalizeExecutablePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal path unchanged",
+			input:    "/path/to/program",
+			expected: "/path/to/program",
+		},
+		{
+			name:     "path with .old suffix",
+			input:    "/path/to/program.old",
+			expected: "/path/to/program",
+		},
+		{
+			name:     "path with leading dot and .old suffix",
+			input:    "/path/to/.minio.old",
+			expected: "/path/to/minio",
+		},
+		{
+			name:     "path with leading dot and .old suffix (complex)",
+			input:    "/usr/local/bin/.server.old",
+			expected: "/usr/local/bin/server",
+		},
+		{
+			name:     "simple filename with .old",
+			input:    "program.old",
+			expected: "program",
+		},
+		{
+			name:     "simple filename with leading dot and .old",
+			input:    ".program.old",
+			expected: "program",
+		},
+		{
+			name:     "path with multiple dots but not .old extension",
+			input:    "/path/to/my.program.exe",
+			expected: "/path/to/my.program.exe",
+		},
+		{
+			name:     "windows style path with .old",
+			input:    "C:\\Program Files\\app.exe.old",
+			expected: "C:\\Program Files\\app.exe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeExecutablePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeExecutablePath(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/minio/selfupdate
 
-go 1.14
+go 1.24
+
+require aead.dev/minisign v0.2.0
 
 require (
-	aead.dev/minisign v0.2.0
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/minio/selfupdate
 
-go 1.24
+go 1.24.0
+
+toolchain go1.24.8
 
 require aead.dev/minisign v0.2.0
 
 require (
-	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/crypto v0.43.0 // indirect
+	golang.org/x/sys v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,16 +5,10 @@ golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b h1:QAqMVf3pSa6eeTsuklijukjXBlj7Es2QQplab+/RbQ4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210228012217-479acdf4ea46/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,15 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b h1:QAqMVf3pSa6eeTsuklijukjXBlj7Es2QQplab+/RbQ4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
+golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210228012217-479acdf4ea46/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
## Description
This PR adds `.old` file normalization to handle cases where `os.Executable()` returns a path ending with `.old` after a previous update on some systems.
- Implements `normalizeExecutablePath()` function to strip `.old` suffix and leading dots from base filenames
- Modifies `getPath()` to normalize executable paths before use
- Adds comprehensive unit tests covering various path scenarios

## Motivation and Context
After a self-update operation, some systems may report the current executable path with a `.old` extension (e.g., `/path/to/.minio.old`). This can cause issues when the updater
tries to determine the target path for the next update.

The implementation addresses:
1. **Strip .old suffix** - Removes `.old` extension from executable paths (lines 244-246)
2. **Remove leading dots** - Handles hidden files like `.minio.old` → `minio` (lines 248-250)
3. **Preserve normal paths** - Unchanged behavior for paths without `.old` extension (lines 254)
4. **Cross-platform support** - Works with Unix and Windows-style paths (lines 244-254)

The normalization handles:
1. Normal paths remain unchanged (lines 258-261 in test)
2. Paths with `.old` suffix are normalized (lines 262-265)
3. Hidden files with `.old` are normalized (lines 266-269, 270-273)
4. Simple filenames with `.old` (lines 274-281)
5. Complex paths preserved (lines 282-285)
6. Windows-style paths supported (lines 286-289)

## How to test this PR?
Run the test suite:
```bash
go test -v -run TestNormalizeExecutablePath
```
See other tests downstream in `eos` here: https://github.com/miniohq/eos/actions/runs/18663370987/job/53209192041
The failures are unrelated and are being discussed with @vadmeste in https://github.com/miniohq/eos/issues/1956


Types of changes

[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Optimization (provides speedup with no functional changes)
[ ] Cleanup/Maintenance (no functional changes)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

Checklist:

[ ] Fixes a regression (If yes, please add commit-id or PR # here)
[x] Unit tests added/updated
[ ] Internal documentation updated
[ ] Create a documentation update request